### PR TITLE
Adapt the code to work with Python3.

### DIFF
--- a/ni_usb_6501.py
+++ b/ni_usb_6501.py
@@ -124,6 +124,31 @@ class NiUsb6501:
 
         return response
 
+    def read_pin(self, port, pin):
+        """
+        Read one pin from a port. This does not make sure that the IO mode is correct
+        """
+        port_response = read_port(port)
+
+        # bit operation to get the bit at pin
+        return (port_response & (1<<pin)) >> pin
+
+    def write_pin(self, port, pin, bit):
+        """
+        Write one pin in a port. This should perserve all other output pins in the port
+        Bit will be interpereted as a boolean
+        """
+        port_response = read_port(port)
+
+        if bit:
+            mask = port_response | (1<<pin)
+        else:
+            mask = port_response & ~(1<<pin)
+
+        write_response = write_port(port, mask)
+
+        return (write_response & (1<<pin)) >> pin
+
     ##########################################################
     # TODO: COUNTERS ARE NOT YET IMPLEMENTED
     ##########################################################

--- a/ni_usb_6501.py
+++ b/ni_usb_6501.py
@@ -66,7 +66,6 @@ class NiUsb6501:
         """ used only internally via get_adapter() and find_adapters() """
         self.device = device
         cfg = self.device.get_active_configuration()
-        print(cfg)
         self.interface_number = cfg[(0, 0)].bInterfaceNumber
         self.io_mask = [0, 0, 0]  # All pins initialize to inputs
 


### PR DESCRIPTION
This commit replaces the string and chr representation of hex arrays with bytearray datatype. The valid range of chr has changed in Python3, which broke the original code. Also some minor clean ups and changed print function to Python3 standard.